### PR TITLE
Fix KeyError when using shippable=True

### DIFF
--- a/src/lbc/utils.py
+++ b/src/lbc/utils.py
@@ -251,7 +251,7 @@ def build_search_payload_with_args(
             payload["filters"]["keywords"]["type"] = "subject"
 
     if shippable:
-        payload["filters"]["locations"]["shippable"] = True
+        payload["filters"]["location"]["shippable"] = True
 
     if kwargs:
         for key, value in kwargs.items():


### PR DESCRIPTION
Using `shippable=True` in `client.search()` was causing a KeyError:

    KeyError: 'locations'

This happened because the code tried to access
`payload["filters"]["locations"]["shippable"]` instead of
`payload["filters"]["location"]["shippable"]`.

This PR fixes the key.
Now the shippable filter works without breaking anything else.
